### PR TITLE
Render linebreaks in gift aid info

### DIFF
--- a/assets/exhibition-date.js
+++ b/assets/exhibition-date.js
@@ -10106,6 +10106,23 @@ var $elm$html$Html$th = _VirtualDom_node('th');
 var $author$project$ExhibitionDate$ClickedUpdateCart = function (a) {
 	return {$: 7, a: a};
 };
+var $author$project$ExhibitionDate$viewGiftAidInfo = function (giftAidInfo) {
+	return A2(
+		$elm$html$Html$div,
+		_List_Nil,
+		A2(
+			$elm$core$List$map,
+			function (paragraph) {
+				return A2(
+					$elm$html$Html$p,
+					_List_Nil,
+					_List_fromArray(
+						[
+							$elm$html$Html$text(paragraph)
+						]));
+			},
+			A2($elm$core$String$split, '<br>', giftAidInfo)));
+};
 var $author$project$ExhibitionDate$viewGiftAidDeclaration = function (giftAidCopy) {
 	return A2(
 		$elm$html$Html$div,
@@ -10122,13 +10139,7 @@ var $author$project$ExhibitionDate$viewGiftAidDeclaration = function (giftAidCop
 					[
 						$elm$html$Html$text(giftAidCopy.aw)
 					])),
-				A2(
-				$elm$html$Html$p,
-				_List_Nil,
-				_List_fromArray(
-					[
-						$elm$html$Html$text(giftAidCopy.ax)
-					])),
+				$author$project$ExhibitionDate$viewGiftAidInfo(giftAidCopy.ax),
 				A2(
 				$elm$html$Html$div,
 				_List_fromArray(

--- a/elm/src/ExhibitionDate.elm
+++ b/elm/src/ExhibitionDate.elm
@@ -846,7 +846,7 @@ viewGiftAidDeclaration : GiftAidCopy -> Html Msg
 viewGiftAidDeclaration giftAidCopy =
     Html.div [ Html.Attributes.class "gift-aid-container" ]
         [ Html.h2 [] [ Html.text giftAidCopy.heading ]
-        , Html.p [] [ Html.text giftAidCopy.info ]
+        , viewGiftAidInfo giftAidCopy.info
         , Html.div [ Html.Attributes.class "add-to-cart-button-container" ]
             [ Html.button
                 [ Html.Attributes.class "button"
@@ -860,6 +860,17 @@ viewGiftAidDeclaration giftAidCopy =
                 [ Html.text "Add to basket without Gift Aid" ]
             ]
         ]
+
+
+viewGiftAidInfo : String -> Html Msg
+viewGiftAidInfo giftAidInfo =
+    Html.div []
+        (List.map
+            (\paragraph ->
+                Html.p [] [ Html.text paragraph ]
+            )
+            (String.split "<br>" giftAidInfo)
+        )
 
 
 ticketDetailString : Model -> String


### PR DESCRIPTION
## Summary: 
Parses gift aid info text into paragraphs via `<br>` tags

Fixes #95.

